### PR TITLE
fix: switch database adapter from PostgreSQL to MongoDB for Vercel de…

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -25,14 +25,14 @@ export default buildConfig({
     user: 'users',
   },
   collections: [Pages, Users, Tenants],
-  // db: mongooseAdapter({
-  //   url: process.env.DATABASE_URI as string,
-  // }),
-  db: postgresAdapter({
-    pool: {
-      connectionString: process.env.POSTGRES_URL,
-    },
+  db: mongooseAdapter({
+    url: process.env.DATABASE_URI as string,
   }),
+  // db: postgresAdapter({
+  //   pool: {
+  //     connectionString: process.env.POSTGRES_URL,
+  //   },
+  // }),
   onInit: async (args) => {
     if (process.env.SEED_DB === 'true') {
       await seed(args)


### PR DESCRIPTION
…ployment

- Comment out PostgreSQL adapter
- Enable MongoDB adapter to use DATABASE_URI
- Fixes ECONNREFUSED error on Vercel